### PR TITLE
Fix black background issue; Add background parameter

### DIFF
--- a/android/src/main/kotlin/com/nover/flutternativeadmob/NativeAdView.kt
+++ b/android/src/main/kotlin/com/nover/flutternativeadmob/NativeAdView.kt
@@ -1,6 +1,7 @@
 package com.nover.flutternativeadmob
 
 import android.content.Context
+import android.content.res.Configuration
 import android.graphics.Color
 import android.graphics.PorterDuff
 import android.util.AttributeSet
@@ -142,6 +143,8 @@ class NativeAdView @JvmOverloads constructor(
   }
 
   private fun updateOptions() {
+    adView.setBackgroundColor(options.backgroundColor)
+
     adMedia?.visibility = if (options.showMediaContent) View.VISIBLE else View.GONE
 
     ratingBar.progressDrawable

--- a/android/src/main/kotlin/com/nover/flutternativeadmob/NativeAdmobOptions.kt
+++ b/android/src/main/kotlin/com/nover/flutternativeadmob/NativeAdmobOptions.kt
@@ -31,6 +31,7 @@ class NativeTextStyle(
 class NativeAdmobOptions(
     var showMediaContent: Boolean = true,
     var ratingColor: Int = Color.YELLOW,
+    var backgroundColor: Int = Color.TRANSPARENT,
     val adLabelTextStyle: NativeTextStyle = NativeTextStyle(12f, Color.WHITE, Color.parseColor("#FFCC66")),
     val headlineTextStyle: NativeTextStyle = NativeTextStyle(16f, Color.BLACK),
     val advertiserTextStyle: NativeTextStyle = NativeTextStyle(14f, Color.BLACK),
@@ -46,6 +47,10 @@ class NativeAdmobOptions(
 
       (data["showMediaContent"] as? Boolean)?.let {
         bannerOptions.showMediaContent = it
+      }
+
+      (data["backgroundColor"] as? String)?.let {
+        bannerOptions.backgroundColor = Color.parseColor(it)
       }
 
       (data["ratingColor"] as? String)?.let {

--- a/android/src/main/res/layout/native_admob_full_view.xml
+++ b/android/src/main/res/layout/native_admob_full_view.xml
@@ -1,15 +1,14 @@
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
+    android:background="@android:color/white"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <com.google.android.gms.ads.formats.UnifiedNativeAdView
         android:id="@+id/ad_view"
-        android:background="@android:color/transparent"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
         <LinearLayout
-            android:background="@android:color/transparent"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:orientation="vertical">

--- a/ios/Classes/NativeAdViews/NativeAdView.swift
+++ b/ios/Classes/NativeAdViews/NativeAdView.swift
@@ -284,7 +284,9 @@ private extension NativeAdView {
     
     func updateOptions() {
         adMediaView.isHidden = !options.showMediaContent
-        
+
+        backgroundColor = options.backgroundColor
+
         adLabelLbl.textColor = options.adLabelTextStyle.color
         adLabelLbl.font = UIFont.systemFont(ofSize: options.adLabelTextStyle.fontSize)
         adLabelView.backgroundColor = options.adLabelTextStyle.backgroundColor ?? .fromHex("FFCC66")

--- a/ios/Classes/NativeAdViews/NativeAdmobOptions.swift
+++ b/ios/Classes/NativeAdViews/NativeAdmobOptions.swift
@@ -35,8 +35,9 @@ struct NativeAdmobOptions {
     }
     
     var showMediaContent: Bool = true
+    var backgroundColor: UIColor?
     var ratingColor: UIColor = .yellow
-    
+
     var adLabelTextStyle = NativeTextStyle(fontSize: 12, color: .white, backgroundColor: .fromHex("FFCC66"))
     var headlineTextStyle = NativeTextStyle(fontSize: 16, color: .black)
     var advertiserTextStyle = NativeTextStyle(fontSize: 14, color: .black)
@@ -50,6 +51,11 @@ struct NativeAdmobOptions {
     init(_ data: [String: Any]) {
         if let showMediaContent = data["showMediaContent"] as? Bool {
             self.showMediaContent = showMediaContent
+        }
+
+
+        if let backgroundColorString = data["backgroundColor"] as? String {
+            backgroundColor = .fromHex(backgroundColorString)
         }
         
         if let ratingColorString = data["ratingColor"] as? String {

--- a/lib/native_admob_options.dart
+++ b/lib/native_admob_options.dart
@@ -14,9 +14,7 @@ class NativeTextStyle {
   });
 
   Map<String, dynamic> toJson() => {
-        "backgroundColor": backgroundColor != null
-            ? "#${backgroundColor.value.toRadixString(16)}"
-            : null,
+        "backgroundColor": backgroundColor != null ? "#${backgroundColor.value.toRadixString(16)}" : null,
         "fontSize": fontSize,
         "color": color != null ? "#${color.value.toRadixString(16)}" : null,
         "isVisible": isVisible,
@@ -26,6 +24,7 @@ class NativeTextStyle {
 class NativeAdmobOptions {
   final bool showMediaContent;
   final Color ratingColor;
+  final Color backgroundColor;
   final NativeTextStyle adLabelTextStyle;
   final NativeTextStyle headlineTextStyle;
   final NativeTextStyle advertiserTextStyle;
@@ -37,6 +36,7 @@ class NativeAdmobOptions {
   const NativeAdmobOptions({
     this.showMediaContent = true,
     this.ratingColor = Colors.yellow,
+    this.backgroundColor,
     this.adLabelTextStyle = const NativeTextStyle(
       fontSize: 12,
       color: Colors.white,
@@ -72,6 +72,7 @@ class NativeAdmobOptions {
   Map<String, dynamic> toJson() => {
         "showMediaContent": this.showMediaContent,
         "ratingColor": "#${ratingColor.value.toRadixString(16)}",
+        "backgroundColor": backgroundColor != null ? "#${backgroundColor.value.toRadixString(16)}" : null,
         "adLabelTextStyle": adLabelTextStyle.toJson(),
         "headlineTextStyle": headlineTextStyle.toJson(),
         "advertiserTextStyle": advertiserTextStyle.toJson(),


### PR DESCRIPTION
Pull request with a fix for the black background issue from Android. To fix the problem a background color can now be set for the native ad.

Regarding issue: https://github.com/duyduong/flutter_native_admob/issues/40

**Changelog:**

- Add parameter for background color
- Fix black background bug on some Android devices